### PR TITLE
fixed errors in create_categories function and updated POST in handler

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -94,13 +94,16 @@ class HandleRequests(BaseHTTPRequestHandler):
             if 'label' in post_body:
                 self._set_headers(201)
                 response = create_tag(post_body)
+        elif resource == 'categories':
+            if 'label' in post_body:
+                self._set_headers(201)
+                response = create_category(post_body)
             else:
                 self._set_headers(400)
                 response = {"message": f'{"Label is required" if "label" not in post_body else""}'}
         if resource == 'posts':
             response = create_post(post_body)
-        if resource == 'categories':
-            response = create_category(post_body)
+
         self.wfile.write(response.encode())
 
     def do_PUT(self):

--- a/views/category_requests.py
+++ b/views/category_requests.py
@@ -28,20 +28,21 @@ def get_all_categories():
 
     return categories
 
-def create_category(new_category):
-    # Get the id value of the last employee in the list
+def create_category(category):
+    """Adds a new category to the database"""
+
     with sqlite3.connect("./db.sqlite3") as conn:
         db_cursor = conn.cursor()
 
         db_cursor.execute("""
         INSERT INTO Categories
-            ( id, label )
+            (label)
         VALUES
-            ( ?, ? )
-        """, (new_category['id'], new_category['label']))
+            (?)
+        """, (category['label'],))
 
         id = db_cursor.lastrowid
 
-        new_category['id'] = id
+        category['id'] = id
 
-    return new_category
+    return json.dumps(category)


### PR DESCRIPTION
Would not post on client side with new code. Updated the request handler POST function and modified the create_category function in category_requests.py. Tested code with debuggers and create category form twice. 

To test this branch:
  - Git fetch –all
  - Git checkout faith-server
  - Pull the new branch in client-side 
  - Run the client app in local 3000
  - import a new category in the form textbox
  - click create category button
  - your new category should be posted to the list of categories

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules